### PR TITLE
Support for reading IP and client limits. 

### DIFF
--- a/ImgurDotNet/ImgurAccount.cs
+++ b/ImgurDotNet/ImgurAccount.cs
@@ -42,7 +42,7 @@ namespace ImgurDotNet
             {
                 isProAcct = (bool)data["pro_expiration"];
             }
-            catch (Exception ex)
+            catch (Exception)
             {
                 isProAcct = true;
                 proAcct = Convert.ToInt64(data["pro_expiration"]);

--- a/ImgurDotNet/ImgurDotNet.csproj
+++ b/ImgurDotNet/ImgurDotNet.csproj
@@ -28,6 +28,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\Release\ImgurDotNet.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />


### PR DESCRIPTION
It only works after any other API call was made, so no additional API calls must be wasted in order to obtain this info.

Also: Proper support for multiple client instances - right now even though ImgurUtils was an instantiable class, only a single instance could be used in reality because the cliendid was static, so if we had multiple instances of ImgurUtils they would have overridden each other's cliend ID.

Also: Formatting to VS defaults. Exporting XML doc in release mode.
